### PR TITLE
Makefile: Use relative paths rather than expanding to absolute paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-SRCDIR=$(realpath ./fqlib/)
-BUILDDIR=$(realpath ./build/)
-DISTDIR=$(realpath ./dist/)
+SRCDIR=./fqlib
+BUILDDIR=./build
+DISTDIR=./dist
 CFLAGS=""
 PXD_FILES=$(wildcard $(SRCDIR)/*.pxd)
 PYX_FILES=$(wildcard $(SRCDIR)/*.pyx)


### PR DESCRIPTION
`realpath` returns an empty string upon failure, e.g., when the
directory does not exist.

Fixes #13 