### PR TITLE
docker: Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tmp/
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.36.0 AS builder
+
+RUN apt-get update \
+    && apt-get --yes install --no-install-recommends \
+        musl-tools \
+    && rm -r /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+COPY Cargo.lock Cargo.toml /tmp/fqlib/
+COPY src/ /tmp/fqlib/src/
+
+RUN cargo build \
+        --release \
+        --manifest-path /tmp/fqlib/Cargo.toml \
+        --target x86_64-unknown-linux-musl
+
+FROM alpine:3.10
+
+COPY --from=builder /tmp/fqlib/target/x86_64-unknown-linux-musl/release/fq /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Use [Cargo] to install fqlib. The binary built is named `fq`.
 $ cargo install --git https://github.com/stjude/fqlib.git
 ```
 
+Alternatively, build the [Docker] image.
+
+```
+$ git clone https://github.com/stjude/fqlib.git
+$ docker build --tag fqlib fqlib
+```
+
 [Cargo]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+[Docker]: https://www.docker.com/
 
 ## Usage
 


### PR DESCRIPTION
This adds a Dockerfile to build a minimalistic image (8.45 MiB).

Note that it does not define an entrypoint, so container commands must
call `fq` manually.